### PR TITLE
Add sample data and README guidance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 .ipynb_checkpoints/
 *.log
 *.csv
+!sample_data/*.csv
 *.sqlite3
 *.db
 .vscode/

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ The notebook, **CyberGrad--My-Cybersecurity-Degree-in-Data-&-Visuals.ipynb**, pr
 📂 SPC-2025-BAS-Cyber-Graduation-Vizs
 📁 notebooks/              # Jupyter notebooks
   🏋️‍♂️ CyberGrad--My-Cybersecurity-Degree-in-Data-&-Visuals.ipynb
-📁 data/                   # Add your CSV files here
+📁 data/                   # Place your personal CSV files here
+📁 sample_data/            # Example CSVs for reference
 📁 images/                 # Contains degree image
 📁 plots/                  # Saves generated charts
 🏋️‍♂️ README.md               # This documentation
@@ -71,11 +72,11 @@ jupyter notebook
 ---
 
 ## 📊 **Data Used**
-The analysis is based on CSV files stored in the `data/` folder (create this directory if it does not exist):
-- **gpa_over_time.csv** – Contains term-wise GPA data.
-- **course_grades_distribution.csv** – Holds course grades for visualization.
+The analysis expects CSV files in the `data/` folder (create this directory if it does not exist).  Sample datasets are provided in `sample_data/`:
+- **gpa_over_time_sample.csv** – Example term GPA data.
+- **course_grades_distribution_sample.csv** – Example course grades.
 
-*(If any dataset is missing, update the paths or use your own data.)*
+You can copy these files into the `data/` folder or replace them with your own data using the same filenames.
 
 ---
 

--- a/sample_data/course_grades_distribution_sample.csv
+++ b/sample_data/course_grades_distribution_sample.csv
@@ -1,0 +1,6 @@
+Course,Grade
+Intro to Cybersecurity,A
+Network Security,A-
+Ethical Hacking,B+
+Digital Forensics,A
+Cloud Security,A

--- a/sample_data/gpa_over_time_sample.csv
+++ b/sample_data/gpa_over_time_sample.csv
@@ -1,0 +1,6 @@
+Term,Term GPA,Cumulative GPA
+Fall 2023,3.7,3.7
+Spring 2024,3.8,3.75
+Summer 2024,3.9,3.8
+Fall 2024,4.0,3.85
+Spring 2025,4.0,3.9


### PR DESCRIPTION
## Summary
- provide dummy CSVs in a new `sample_data` folder
- allow Git to track sample CSVs via `.gitignore` update
- document sample files and how to use them in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840ddf304bc8320b5e33e84ffcc8aaf