### PR TITLE
Add pandas-based tests and fix CI Python version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.11'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/tests/test_sample_data.py
+++ b/tests/test_sample_data.py
@@ -1,0 +1,22 @@
+import pandas as pd
+from pathlib import Path
+
+
+def test_gpa_over_time_columns():
+    df = pd.read_csv(Path('sample_data/gpa_over_time_sample.csv'))
+    assert list(df.columns) == ['Term', 'Term GPA', 'Cumulative GPA']
+
+
+def test_course_grades_distribution_columns():
+    df = pd.read_csv(Path('sample_data/course_grades_distribution_sample.csv'))
+    assert list(df.columns) == ['Course', 'Grade']
+
+
+def test_credits_attempted_vs_gpa_columns():
+    df = pd.read_csv(Path('sample_data/credits_attempted_vs_gpa_sample.csv'))
+    assert list(df.columns) == ['Term', 'Credits Attempted', 'Cumulative GPA']
+
+
+def test_milestones_columns():
+    df = pd.read_csv(Path('sample_data/milestones_sample.csv'))
+    assert list(df.columns) == ['Date', 'Milestone']


### PR DESCRIPTION
## Summary
- add basic tests for sample CSVs using pandas
- pin CI workflow to Python 3.11 so pandas installs correctly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6840e154841c8320adc4ac9dcff360fb